### PR TITLE
[go] use go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/fumin/ctw
+
+go 1.17
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Small fix to support go modules.

### Issue before fix

```bash
go run compress/main.go gettysburg.txt > gettys.ctw
compress/main.go:9:2: no required module provides package github.com/fumin/ctw: go.mod file not found in current directory or any parent directory; see 'go help modules
```

Btw, many thanks for sharing your CTW implementation.